### PR TITLE
testes de ECS rodam da branch proto-base

### DIFF
--- a/.github/workflows/ECS_checks.yml
+++ b/.github/workflows/ECS_checks.yml
@@ -1,16 +1,35 @@
 name: ECS Checks
 
 on:
-  pull_request:
+  pull_request_target:
+
+permissions:
+  contents: read
 
 jobs:
   ecs-structure-checks:
     name: 'ECS checks'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - run: python .github/scripts/ecs_check_structure.py
-    - run: python .github/scripts/ecs_check_components.py
-    - run: python .github/scripts/ecs_check_events.py
-    - run: python .github/scripts/ecs_check_event_args.py
-    - run: python .github/scripts/ecs_check_systems.py
+      - name: Checkout proto-base (for official scripts)
+        uses: actions/checkout@v4
+        with:
+          ref: proto-base
+          fetch-depth: 0
+
+      - name: Fetch PR branch (code under test)
+        run: |
+          git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:pr-head
+          git checkout pr-head -- .
+
+      - name: Restore test scripts from proto-base
+        run: |
+          git checkout proto-base -- .github/scripts
+
+      - name: Run ECS checks
+        run: |
+          python .github/scripts/ecs_check_structure.py
+          python .github/scripts/ecs_check_components.py
+          python .github/scripts/ecs_check_events.py
+          python .github/scripts/ecs_check_event_args.py
+          python .github/scripts/ecs_check_systems.py

--- a/.github/workflows/ECS_checks.yml
+++ b/.github/workflows/ECS_checks.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - run: python .github/scripts/ecs_check_event_args.py
     - run: python .github/scripts/ecs_check_structure.py
-    - run: python .github/scripts/ecs_check_events.py
-    - run: python .github/scripts/ecs_check_systems.py
     - run: python .github/scripts/ecs_check_components.py
+    - run: python .github/scripts/ecs_check_events.py
+    - run: python .github/scripts/ecs_check_event_args.py
+    - run: python .github/scripts/ecs_check_systems.py


### PR DESCRIPTION
## Descrição
Isso evita que testes desatualizados sejam rodados em PRs cujas branches estão muito atras de proto-base
<!--
Qual problema resolve ou qual feature adiciona.
e.g., Adiciona endpoint de autenticação com JWT e integra com o módulo de usuários.
-->

## Issues relacionadas
<!--
Feche ou vincule as issues relacionadas usando as palavras-chave do GitHub:
e.g.,
Closes #12  
Fixes #45  
Related to #78
-->

## Checklist
<!--
Marque os itens que se aplicam
a cada check faltando é marcado um mais na divida tecnica
-->
- [x] Código segue o padrão de estilo
- [x] Testes adicionados ou atualizados
- [ ] Documentação atualizada (README)
- [ ] Mudança foi testada localmente
- [x] Nenhuma regressão aparente
- [x] Todos os commits seguem a convenção (`feat:`, `fix:`, etc.)


## Evidências (opcional)
<!--
Adicione prints, logs, ou GIFs demonstrando o funcionamento (caso visual ou de UI).
-->

## Notas (opcional)
<!--
Inclua observações técnicas, decisões de design, ou TODOs futuros.
-->